### PR TITLE
pterodon: Fix error while compiling

### DIFF
--- a/framework.cpp
+++ b/framework.cpp
@@ -201,13 +201,13 @@ size_t Pterodon::Framework::get_io_blksize(int fd) {
 struct stat st;
 /* don't bother with the increase of the default value,
 * as far as i tested it 128KB seems to be fine  */
-unsigned long ret = 128*1024;
+int ret = 128*1024;
 if (fstat(fd, &st) < 0) {
 LOGW("io_blksize: Failed to fstat fd! (%s)", strerror(errno));
 return ret;
 }
 /* if the optimal read/write value from st_blksize is bigger than 128KB, then use it */
-if (st.st_blksize > ret)
+if ((unsigned long)st.st_blksize > (unsigned long)ret)
 ret = st.st_blksize;
 /* caller is expected to already log some current active process,
 *   so that this info isn't completely useless                                     */


### PR DESCRIPTION
return values were int and long int in difference devices, so use long for comparisons